### PR TITLE
Update path to Manifest.xml to fix 404

### DIFF
--- a/About/Manifest.xml
+++ b/About/Manifest.xml
@@ -3,6 +3,6 @@
 <Manifest>
   <identifier>Dubs Rimkit</identifier>
   <version>1.4.953</version>
-  <manifestUri>https://github.com/Dubwise56/Rimkit/master/About/Manifest.xml</manifestUri>
+  <manifestUri>https://github.com/Dubwise56/Rimkit/raw/master/About/Manifest.xml</manifestUri>
   <downloadUri>https://github.com/Dubwise56/Rimkit/releases/latest</downloadUri>
 </Manifest>


### PR DESCRIPTION
I get 404 errors because the old URL doesn't point to the raw Manifest.xml anymore.
inserted "raw/" into the path should fix this.